### PR TITLE
feat: シェアボタンを追加

### DIFF
--- a/app/aiming/page.tsx
+++ b/app/aiming/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from "react"
+import React, { useMemo } from "react"
 import Modal from "react-modal"
 import { useTimer } from "react-timer-hook"
 import { FormEvent, useState, useRef, useEffect } from "react"
@@ -13,6 +13,7 @@ const skipSeconds = 2
 const maxLife = 3
 const defaultButtonSize = 20
 
+const hashTag = "広告消しチャレンジ"
 
 export default function Create() {
     const modalStyleBase: ReactModal.Styles = {
@@ -87,6 +88,11 @@ export default function Create() {
             background: `center / contain url('/ads/popup${v}.webp')`
         }
     })))
+
+    const shareText = useMemo(
+      () => `広告消しチャレンジで${countDestroy}個の広告を正確に消しました！（最終サイズ：${buttonSize}mm）`,
+      [buttonSize, countDestroy]
+    )
 
     useEffect(() => {
         // 物理ボタン入力受付
@@ -493,9 +499,26 @@ export default function Create() {
                     {showOverlay && <div className="clear-overlay-box" style={{
                         background: "center / contain url('/ads/overlay.webp')"
                     }}></div>}
-                    {gameClear && <button className="btn btn-warning btn-lg mb-3 score-board-btn2" onClick={() => {
-                        window.location.href = "/"
-                    }}>トップに戻る</button>}
+                    {gameClear && <>
+                        <button className="btn btn-warning btn-lg mb-3 score-board-btn2" onClick={() => {
+                            window.location.href = "/"
+                        }}>トップに戻る</button>
+                        <div className="flex flex-row score-board-share-row">
+                            <button className="btn btn-primary" onClick={() => {
+                                const params = new URLSearchParams()
+                                params.append("url", `${window.location.protocol}//${window.location.host}`)
+                                params.append("text", shareText)
+                                params.append("hashtags", hashTag)
+                                window.open(`https://twitter.com/intent/tweet?${params.toString()}`)
+                            }}>Twitterでシェア</button>
+                            <button className="btn btn-success" onClick={() => {
+                                const params = new URLSearchParams()
+                                params.append("url", `${window.location.protocol}//${window.location.host}`)
+                                params.append("text", `${shareText} #${hashTag}`)
+                                window.open(`https://misskeyshare.link/share.html?${params.toString()}`)
+                            }}>Misskeyでシェア</button>
+                        </div>
+                    </>}
                     {gameClear && <button className="btn btn-primary btn-lg mb-3 score-board-btn" onClick={handleGameStart}>もう一度チャレンジ</button>}
                     <div className="pointer-item" style={{left: pointer[0]-40, top: pointer[1]-40, display: playing ? pointerDisplay : "none"}}>
                         <svg className="pointer" width="80" height="80">

--- a/app/globals.css
+++ b/app/globals.css
@@ -49,6 +49,15 @@ html {
   height: 8%;
   font-size: 2rem !important;
 }
+.score-board-share-row {
+  position: absolute;
+  z-index: 30;
+  top: 80%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 1.5em;
+  gap: 10px;
+}
 .start-btn {
   position: relative;
   width: 50%;

--- a/app/speed/page.tsx
+++ b/app/speed/page.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from "react"
+import React, { useMemo } from "react"
 import Modal from "react-modal"
 import { useTimer } from "react-timer-hook"
 import { FormEvent, useState, useRef, useEffect } from "react"
@@ -9,8 +9,9 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 const hueBridgeIP = process.env.NEXT_PUBLIC_HUE_BRIDGE_IP
 const hueUser = process.env.NEXT_PUBLIC_HUE_USER
 const numberOfAds = 10
-const timerSeconds = 30
+const timerSeconds = 1
 
+const hashTag = "広告消しチャレンジ"
 
 export default function Create() {
     const modalStyleBase: ReactModal.Styles = {
@@ -83,6 +84,15 @@ export default function Create() {
             background: `center / contain url('/ads/popup${v}.webp')`
         }
     })))
+
+    const missRate = useMemo(() => {
+      const missRate = Math.round(countMistake * 100 / (countDestroy + countMistake))
+      return Number.isNaN(missRate) ? 0 : missRate
+    }, [countMistake, countDestroy])
+    const shareText = useMemo(
+      () => `広告消しチャレンジで${countDestroy}個の広告を消しました！（ミス率${missRate}%）`,
+      [countDestroy, missRate]
+    )
 
     // 制限時間からDateオブジェクトを作成
     const expiryTimestamp = new Date();
@@ -463,10 +473,7 @@ export default function Create() {
                                         stroke-width="8" stroke="#e91e63" fill="none"/>
                                 </svg>
                                 <div className="timer-time">
-                                    {(() => {
-                                        const missRate = Math.round(countMistake * 100 / (countDestroy + countMistake))
-                                        return Number.isNaN(missRate) ? 0 : missRate
-                                    })()}
+                                    {missRate}
                                 </div>
                                 <p>ミス率%</p>
                             </div>
@@ -475,9 +482,26 @@ export default function Create() {
                     {showOverlay && <div className="overlay-box" style={{
                         background: "center / contain url('/ads/overlay.webp')"
                     }} onClick={handleTapMissArea}></div>}
-                    {gameClear && <button className="btn btn-warning btn-lg mb-3 score-board-btn2" onClick={() => {
-                        window.location.href = "/"
-                    }}>トップに戻る</button>}
+                    {gameClear && <>
+                        <button className="btn btn-warning btn-lg mb-3 score-board-btn2" onClick={() => {
+                            window.location.href = "/"
+                        }}>トップに戻る</button>
+                        <div className="flex flex-row score-board-share-row">
+                            <button className="btn btn-primary" onClick={() => {
+                                const params = new URLSearchParams()
+                                params.append("url", `${window.location.protocol}//${window.location.host}`)
+                                params.append("text", shareText)
+                                params.append("hashtags", hashTag)
+                                window.open(`https://twitter.com/intent/tweet?${params.toString()}`)
+                            }}>Twitterでシェア</button>
+                            <button className="btn btn-success" onClick={() => {
+                                const params = new URLSearchParams()
+                                params.append("url", `${window.location.protocol}//${window.location.host}`)
+                                params.append("text", `${shareText} #${hashTag}`)
+                                window.open(`https://misskeyshare.link/share.html?${params.toString()}`)
+                            }}>Misskeyでシェア</button>
+                        </div>
+                    </>}
                     {gameClear && <button className="btn btn-primary btn-lg mb-3 score-board-btn" onClick={handleGameStart}>もう一度チャレンジ</button>}
                     <div className="pointer-item" style={{left: pointer[0]-40, top: pointer[1]-40, display: playing ? pointerDisplay : "none"}}>
                         <svg className="pointer" width="80" height="80">

--- a/app/speed/page.tsx
+++ b/app/speed/page.tsx
@@ -9,7 +9,7 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 const hueBridgeIP = process.env.NEXT_PUBLIC_HUE_BRIDGE_IP
 const hueUser = process.env.NEXT_PUBLIC_HUE_USER
 const numberOfAds = 10
-const timerSeconds = 1
+const timerSeconds = 30
 
 const hashTag = "広告消しチャレンジ"
 


### PR DESCRIPTION
リザルト画面にシェアボタンを追加します。
![image](https://github.com/user-attachments/assets/cde4133c-03d8-490e-8a1b-8537f20e0f6a)

具体的にはこのようなテキストになります：
> 広告消しチャレンジで0個の広告を消しました！（ミス率0%） http://localhost:3000 #広告消しチャレンジ 

https://x.com/intent/post?url=http%3A%2F%2Flocalhost%3A3000&text=広告消しチャレンジで0個の広告を消しました！（ミス率0%25）&hashtags=広告消しチャレンジ

（フォーマッターはありますか？）